### PR TITLE
QoL Improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,14 +56,16 @@ jobs:
         run: |
           mkdir -p display-u6143/DEBIAN/postinst.d
           echo "#!/bin/bash" > display-u6143/DEBIAN/postinst.d/display-u6143
-          echo "systemctl --now enable display-u6143.service" >> display-u6143/DEBIAN/postinst.d/display-u6143
+          echo "systemctl enable display-u6143.service" >> display-u6143/DEBIAN/postinst.d/display-u6143
+          echo "systemctl start display-u6143.service" >> display-u6143/DEBIAN/postinst.d/display-u6143
           chmod +x display-u6143/DEBIAN/postinst.d/display-u6143
 
       - name: Create postrm script
         run: |
           mkdir -p display-u6143/DEBIAN/postrm.d
           echo "#!/bin/bash" > display-u6143/DEBIAN/postrm.d/display-u6143
-          echo "systemctl --now disable display-u6143.service" >> display-u6143/DEBIAN/postrm.d/display-u6143
+          echo "systemctl stop display-u6143.service" >> display-u6143/DEBIAN/postrm.d/display-u6143
+          echo "systemctl disable display-u6143.service" >> display-u6143/DEBIAN/postrm.d/display-u6143
           chmod +x display-u6143/DEBIAN/postrm.d/display-u6143
 
       - name: Build .deb package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           mkdir -p display-u6143/DEBIAN/postrm.d
           echo "#!/bin/bash" > display-u6143/DEBIAN/postrm.d/display-u6143
-          echo "systemctl disable display-u6143.service" >> display-u6143/DEBIAN/postrm.d/display-u6143
+          echo "systemctl --now disable display-u6143.service" >> display-u6143/DEBIAN/postrm.d/display-u6143
           chmod +x display-u6143/DEBIAN/postrm.d/display-u6143
 
       - name: Build .deb package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Get version from git tag, removing 'v' prefix, default to 1.0.0 for manual runs
+      - name: Set Version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "PKG_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          else
+            echo "PKG_VERSION=1.0.0" >> $GITHUB_ENV
+          fi
+
       - name: Build binary
         run: |
           cd C && make clean && make && cd ..
@@ -31,7 +40,7 @@ jobs:
         run: |
           mkdir -p display-u6143/DEBIAN
           echo "Package: display-u6143" > display-u6143/DEBIAN/control
-          echo "Version: 1.0" >> display-u6143/DEBIAN/control
+          echo "Version: ${{ env.PKG_VERSION }}" >> display-u6143/DEBIAN/control
           echo "Section: utils" >> display-u6143/DEBIAN/control
           echo "Priority: optional" >> display-u6143/DEBIAN/control
           echo "Architecture: arm64" >> display-u6143/DEBIAN/control

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,29 @@ jobs:
 
       - name: Install nfpm
         run: |
-          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+          wget -qO- https://github.com/goreleaser/nfpm/releases/download/v2.41.3/nfpm_2.41.3_Linux_x86_64.tar.gz | tar -xz nfpm
+          chmod +x nfpm
 
       - name: Create packages
         run: |
-          nfpm pkg --packager=rpm --target=display-u6143.rpm
-          nfpm pkg --packager=deb --target=display-u6143.deb
-          nfpm pkg --packager=apk --target=display-u6143.apk
+          ./nfpm pkg --packager=rpm --target=display-u6143.rpm
+          ./nfpm pkg --packager=deb --target=display-u6143.deb
+          ./nfpm pkg --packager=apk --target=display-u6143.apk
+
+
+      - name: Create deb package
+        id: nfpm-deb
+        uses: burningalchemist/action-gh-nfpm@v1
+        with:
+          packager: deb
+          target: display-u6143.deb
+
+      - name: Create apk package
+        id: nfpm-apk
+        uses: burningalchemist/action-gh-nfpm@v1
+        with:
+          packager: apk
+          target: display-u6143.apk
 
       - name: Create GitHub Release
         uses: meeDamian/github-release@2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,32 +46,15 @@ jobs:
             echo "PKG_VERSION=1.0.0" >> $GITHUB_ENV
           fi
 
-      - name: Test environment
+      - name: Install nfpm
         run: |
-          echo "maintainer: ${GITHUB_ACTOR} <${GITHUB_ACTOR}@users.noreply.github.com>"
-          echo "vendor: ${GITHUB_REPOSITORY_OWNER}"
-          echo "homepage: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
 
-      - name: Create rpm package
-        id: nfpm-rpm
-        uses: burningalchemist/action-gh-nfpm@v1
-        with:
-          packager: rpm
-          target: display-u6143.rpm
-
-      - name: Create deb package
-        id: nfpm-deb
-        uses: burningalchemist/action-gh-nfpm@v1
-        with:
-          packager: deb
-          target: display-u6143.deb
-
-      - name: Create apk package
-        id: nfpm-apk
-        uses: burningalchemist/action-gh-nfpm@v1
-        with:
-          packager: apk
-          target: display-u6143.apk
+      - name: Create packages
+        run: |
+          nfpm pkg --packager=rpm --target=display-u6143.rpm
+          nfpm pkg --packager=deb --target=display-u6143.deb
+          nfpm pkg --packager=apk --target=display-u6143.apk
 
       - name: Create GitHub Release
         uses: meeDamian/github-release@2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,20 @@ jobs:
           echo "Maintainer: Josh H <example@example.com>" >> display-u6143/DEBIAN/control
           echo "Description: Pi Rack (U6143) OLED display service" >> display-u6143/DEBIAN/control
 
+      - name: Create postinst script
+        run: |
+          mkdir -p display-u6143/DEBIAN/postinst.d
+          echo "#!/bin/bash" > display-u6143/DEBIAN/postinst.d/display-u6143
+          echo "systemctl --now enable display-u6143.service" >> display-u6143/DEBIAN/postinst.d/display-u6143
+          chmod +x display-u6143/DEBIAN/postinst.d/display-u6143
+
+      - name: Create postrm script
+        run: |
+          mkdir -p display-u6143/DEBIAN/postrm.d
+          echo "#!/bin/bash" > display-u6143/DEBIAN/postrm.d/display-u6143
+          echo "systemctl disable display-u6143.service" >> display-u6143/DEBIAN/postrm.d/display-u6143
+          chmod +x display-u6143/DEBIAN/postrm.d/display-u6143
+
       - name: Build .deb package
         run: dpkg-deb --build display-u6143
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build binary
+        run: |
+          cd C && make clean && make && cd ..
+          mkdir -p display-u6143/usr/local/bin
+          cp C/display display-u6143/usr/local/bin/
+          # Also copy binary to root for raw artifact
+          cp C/display ./display-binary
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: display-binary
+          path: display-binary
+
+      - name: Add systemd service
+        run: |
+          mkdir -p display-u6143/lib/systemd/system
+          cp contrib/U6143_ssd1306.service display-u6143/lib/systemd/system/display-u6143.service
+
+      - name: Create control file
+        run: |
+          mkdir -p display-u6143/DEBIAN
+          echo "Package: display-u6143" > display-u6143/DEBIAN/control
+          echo "Version: 1.0" >> display-u6143/DEBIAN/control
+          echo "Section: utils" >> display-u6143/DEBIAN/control
+          echo "Priority: optional" >> display-u6143/DEBIAN/control
+          echo "Architecture: arm64" >> display-u6143/DEBIAN/control
+          echo "Maintainer: Josh H <example@example.com>" >> display-u6143/DEBIAN/control
+          echo "Description: Pi Rack (U6143) OLED display service" >> display-u6143/DEBIAN/control
+
+      - name: Build .deb package
+        run: dpkg-deb --build display-u6143
+
+      - name: Group Artifacts
+        run: |
+          mkdir -p build/display-u6143
+          mv display-u6143.deb build/display-u6143/
+          mv display-binary build/display-u6143/
+
+      - name: Release
+        uses: fnkr/github-action-ghr@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GHR_COMPRESS: xz
+          GHR_PATH: build/display-u6143
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,12 +48,9 @@ jobs:
 
       - name: Test environment
         run: |
-          echo "maintainer: '${GITHUB_ACTOR} <${GITHUB_ACTOR}@users.noreply.github.com>"
-          description: |
-            Pi Rack (U6143) OLED display service
-          vendor: "${GITHUB_REPOSITORY_OWNER}"
-          homepage: "${$GITHUB_SERVER_URL/$GITHUB_REPOSITORY}"'
-          
+          echo "maintainer: ${GITHUB_ACTOR} <${GITHUB_ACTOR}@users.noreply.github.com>"
+          echo "vendor: ${GITHUB_REPOSITORY_OWNER}"
+          echo "homepage: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
 
       - name: Create rpm package
         id: nfpm-rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,86 @@ jobs:
           mkdir -p display-u6143/lib/systemd/system
           cp contrib/U6143_ssd1306.service display-u6143/lib/systemd/system/display-u6143.service
 
+      # Create Alpine package structure
+      - name: Setup Alpine package
+        run: |
+          mkdir -p alpine/display-u6143/usr/local/bin
+          mkdir -p alpine/display-u6143/etc/init.d
+          cp C/display alpine/display-u6143/usr/local/bin/
+          # Create OpenRC init script
+          cat > alpine/display-u6143/etc/init.d/display-u6143 << 'EOF'
+          #!/sbin/openrc-run
+          
+          name="display-u6143"
+          command="/usr/local/bin/display"
+          command_background="yes"
+          pidfile="/run/${RC_SVCNAME}.pid"
+          
+          depend() {
+              need net
+              after bootmisc
+          }
+          EOF
+          chmod +x alpine/display-u6143/etc/init.d/display-u6143
+
+      - name: Create APKBUILD
+        run: |
+          mkdir -p alpine
+          cat > alpine/APKBUILD << EOF
+          # Contributor: Josh H <example@example.com>
+          # Maintainer: Josh H <example@example.com>
+          pkgname=display-u6143
+          pkgver=\${{ env.PKG_VERSION }}
+          pkgrel=0
+          pkgdesc="Pi Rack (U6143) OLED display service"
+          url="https://github.com/yourusername/U6143_ssd1306"
+          arch="aarch64"
+          license="MIT"
+          depends=""
+          install="\$pkgname.post-install \$pkgname.post-deinstall"
+          source=""
+          options="!check"
+          
+          package() {
+              cp -r \$srcdir/display-u6143/* \$pkgdir/
+          }
+          EOF
+          
+          # Create post-install script
+          cat > alpine/display-u6143.post-install << 'EOF'
+          #!/bin/sh
+          rc-update add display-u6143 default
+          rc-service display-u6143 start
+          EOF
+          
+          # Create post-deinstall script
+          cat > alpine/display-u6143.post-deinstall << 'EOF'
+          #!/bin/sh
+          rc-service display-u6143 stop
+          rc-update del display-u6143 default
+          EOF
+
+      - name: Install Alpine build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y alpine-sdk
+
+      - name: Build APK package
+        run: |
+          cd alpine
+          abuild-keygen -a -i -n
+          abuild -r
+          mkdir -p packages/aarch64
+          mv /home/runner/packages/*/aarch64/display-u6143-${{ env.PKG_VERSION }}-r0.apk packages/aarch64/
+          cd ..
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: display-u6143-apk
+          path: alpine/packages/aarch64/display-u6143-${{ env.PKG_VERSION }}-r0.apk
+
+      # Continue with Debian package creation
       - name: Create control file
         run: |
           mkdir -p display-u6143/DEBIAN
@@ -95,6 +175,7 @@ jobs:
           body: |
             This release includes:
             - `.deb` package for ARM64
+            - `.apk` package for Alpine Linux (aarch64)
             - Raw binary for ARM64
           draft: false
           prerelease: false
@@ -102,3 +183,4 @@ jobs:
           files: >
             display-u6143.deb
             display-binary
+            display-u6143.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Build binary
+        run: |
+          cd C && make clean && make && cd ..
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: display-binary
+          path: display-binary
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: display-binary
+
       - name: Set Version
         run: |
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
@@ -22,150 +45,26 @@ jobs:
             echo "PKG_VERSION=1.0.0" >> $GITHUB_ENV
           fi
 
-      - name: Build binary
-        run: |
-          cd C && make clean && make && cd ..
-          mkdir -p display-u6143/usr/local/bin
-          cp C/display display-u6143/usr/local/bin/
-          # Also copy binary to root for raw artifact
-          cp C/display ./display-binary
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+      - name: Create rpm package
+        id: nfpm-rpm
+        uses: burningalchemist/action-gh-nfpm@v1
         with:
-          name: display-binary
-          path: display-binary
+          packager: rpm
+          target: display-u6143.rpm
 
-      - name: Add systemd service
-        run: |
-          mkdir -p display-u6143/lib/systemd/system
-          cp contrib/U6143_ssd1306.service display-u6143/lib/systemd/system/display-u6143.service
-
-      # Create Alpine package structure
-      - name: Setup Alpine package
-        run: |
-          mkdir -p alpine/display-u6143/usr/local/bin
-          mkdir -p alpine/display-u6143/etc/init.d
-          cp C/display alpine/display-u6143/usr/local/bin/
-          # Create OpenRC init script
-          cat > alpine/display-u6143/etc/init.d/display-u6143 << 'EOF'
-          #!/sbin/openrc-run
-          
-          name="display-u6143"
-          command="/usr/local/bin/display"
-          command_background="yes"
-          pidfile="/run/${RC_SVCNAME}.pid"
-          
-          depend() {
-              need net
-              after bootmisc
-          }
-          EOF
-          chmod +x alpine/display-u6143/etc/init.d/display-u6143
-
-      - name: Create APKBUILD
-        run: |
-          mkdir -p alpine
-          cat > alpine/APKBUILD << EOF
-          # Contributor: Josh H <example@example.com>
-          # Maintainer: Josh H <example@example.com>
-          pkgname=display-u6143
-          pkgver=\${{ env.PKG_VERSION }}
-          pkgrel=0
-          pkgdesc="Pi Rack (U6143) OLED display service"
-          url="https://github.com/yourusername/U6143_ssd1306"
-          arch="aarch64"
-          license="MIT"
-          depends=""
-          install="\$pkgname.post-install \$pkgname.post-deinstall"
-          source=""
-          options="!check"
-          
-          package() {
-              cp -r \$srcdir/display-u6143/* \$pkgdir/
-          }
-          EOF
-          
-          # Create post-install script
-          cat > alpine/display-u6143.post-install << 'EOF'
-          #!/bin/sh
-          rc-update add display-u6143 default
-          rc-service display-u6143 start
-          EOF
-          
-          # Create post-deinstall script
-          cat > alpine/display-u6143.post-deinstall << 'EOF'
-          #!/bin/sh
-          rc-service display-u6143 stop
-          rc-update del display-u6143 default
-          EOF
-
-      - name: Install Alpine build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y alpine-sdk
-
-      - name: Build APK package
-        run: |
-          cd alpine
-          abuild-keygen -a -i -n
-          abuild -r
-          mkdir -p packages/aarch64
-          mv /home/runner/packages/*/aarch64/display-u6143-${{ env.PKG_VERSION }}-r0.apk packages/aarch64/
-          cd ..
-
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+      - name: Create deb package
+        id: nfpm-deb
+        uses: burningalchemist/action-gh-nfpm@v1
         with:
-          name: display-u6143-apk
-          path: alpine/packages/aarch64/display-u6143-${{ env.PKG_VERSION }}-r0.apk
+          packager: deb
+          target: display-u6143.deb
 
-      # Continue with Debian package creation
-      - name: Create control file
-        run: |
-          mkdir -p display-u6143/DEBIAN
-          echo "Package: display-u6143" > display-u6143/DEBIAN/control
-          echo "Version: ${{ env.PKG_VERSION }}" >> display-u6143/DEBIAN/control
-          echo "Section: utils" >> display-u6143/DEBIAN/control
-          echo "Priority: optional" >> display-u6143/DEBIAN/control
-          echo "Architecture: arm64" >> display-u6143/DEBIAN/control
-          echo "Maintainer: Josh H <example@example.com>" >> display-u6143/DEBIAN/control
-          echo "Description: Pi Rack (U6143) OLED display service" >> display-u6143/DEBIAN/control
-
-      - name: Create postinst script
-        run: |
-          mkdir -p display-u6143/DEBIAN/postinst.d
-          echo "#!/bin/bash" > display-u6143/DEBIAN/postinst.d/display-u6143
-          echo "systemctl enable display-u6143.service" >> display-u6143/DEBIAN/postinst.d/display-u6143
-          echo "systemctl start display-u6143.service" >> display-u6143/DEBIAN/postinst.d/display-u6143
-          chmod +x display-u6143/DEBIAN/postinst.d/display-u6143
-
-      - name: Create postrm script
-        run: |
-          mkdir -p display-u6143/DEBIAN/postrm.d
-          echo "#!/bin/bash" > display-u6143/DEBIAN/postrm.d/display-u6143
-          echo "systemctl stop display-u6143.service" >> display-u6143/DEBIAN/postrm.d/display-u6143
-          echo "systemctl disable display-u6143.service" >> display-u6143/DEBIAN/postrm.d/display-u6143
-          chmod +x display-u6143/DEBIAN/postrm.d/display-u6143
-
-      - name: Build .deb package
-        run: dpkg-deb --build display-u6143
-
-      - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+      - name: Create apk package
+        id: nfpm-apk
+        uses: burningalchemist/action-gh-nfpm@v1
         with:
-          name: display-u6143
-          path: display-u6143.deb
-
-  release:
-    needs: build
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
+          packager: apk
+          target: display-u6143.apk
 
       - name: Create GitHub Release
         uses: meeDamian/github-release@2.0
@@ -175,6 +74,7 @@ jobs:
           body: |
             This release includes:
             - `.deb` package for ARM64
+            - `.rpm` package for ARM64
             - `.apk` package for Alpine Linux (aarch64)
             - Raw binary for ARM64
           draft: false
@@ -182,5 +82,6 @@ jobs:
           gzip: folders
           files: >
             display-u6143.deb
-            display-binary
+            display-u6143.rpm
             display-u6143.apk
+            display-binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,21 +57,6 @@ jobs:
           ./nfpm pkg --packager=deb --target=display-u6143.deb
           ./nfpm pkg --packager=apk --target=display-u6143.apk
 
-
-      - name: Create deb package
-        id: nfpm-deb
-        uses: burningalchemist/action-gh-nfpm@v1
-        with:
-          packager: deb
-          target: display-u6143.deb
-
-      - name: Create apk package
-        id: nfpm-apk
-        uses: burningalchemist/action-gh-nfpm@v1
-        with:
-          packager: apk
-          target: display-u6143.apk
-
       - name: Create GitHub Release
         uses: meeDamian/github-release@2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 jobs:
   build:
@@ -14,15 +13,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Get version from git tag, removing 'v' prefix, default to 1.0.0 for manual runs
-      - name: Set Version
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "PKG_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-          else
-            echo "PKG_VERSION=1.0.0" >> $GITHUB_ENV
-          fi
-
       - name: Build binary
         run: |
           cd C && make clean && make && cd ..
@@ -30,6 +20,12 @@ jobs:
           cp C/display display-u6143/usr/local/bin/
           # Also copy binary to root for raw artifact
           cp C/display ./display-binary
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: display-binary
+          path: display-binary
 
       - name: Add systemd service
         run: |
@@ -40,7 +36,7 @@ jobs:
         run: |
           mkdir -p display-u6143/DEBIAN
           echo "Package: display-u6143" > display-u6143/DEBIAN/control
-          echo "Version: ${{ env.PKG_VERSION }}" >> display-u6143/DEBIAN/control
+          echo "Version: 1.0" >> display-u6143/DEBIAN/control
           echo "Section: utils" >> display-u6143/DEBIAN/control
           echo "Priority: optional" >> display-u6143/DEBIAN/control
           echo "Architecture: arm64" >> display-u6143/DEBIAN/control
@@ -50,16 +46,34 @@ jobs:
       - name: Build .deb package
         run: dpkg-deb --build display-u6143
 
-      - name: Group Artifacts
-        run: |
-          mkdir -p build/display-u6143
-          mv display-u6143.deb build/display-u6143/
-          mv display-binary build/display-u6143/
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: display-u6143
+          path: display-u6143.deb
 
-      - name: Release
-        uses: fnkr/github-action-ghr@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GHR_COMPRESS: xz
-          GHR_PATH: build/display-u6143
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release:
+    needs: build
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.ref_name }}
+          body: |
+            This release includes:
+            - `.deb` package for ARM64
+            - Raw binary for ARM64
+          draft: false
+          prerelease: false
+          gzip: folders
+          files: >
+            display-u6143.deb
+            display-binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,6 @@ jobs:
           # Also copy binary to root for raw artifact
           cp C/display ./display-binary
 
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: display-binary
-          path: display-binary
-
       - name: Add systemd service
         run: |
           mkdir -p display-u6143/lib/systemd/system

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -12,6 +13,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set Version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "PKG_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          else
+            echo "PKG_VERSION=1.0.0" >> $GITHUB_ENV
+          fi
 
       - name: Build binary
         run: |
@@ -36,7 +45,7 @@ jobs:
         run: |
           mkdir -p display-u6143/DEBIAN
           echo "Package: display-u6143" > display-u6143/DEBIAN/control
-          echo "Version: 1.0" >> display-u6143/DEBIAN/control
+          echo "Version: ${{ env.PKG_VERSION }}" >> display-u6143/DEBIAN/control
           echo "Section: utils" >> display-u6143/DEBIAN/control
           echo "Priority: optional" >> display-u6143/DEBIAN/control
           echo "Architecture: arm64" >> display-u6143/DEBIAN/control

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,15 @@ jobs:
             echo "PKG_VERSION=1.0.0" >> $GITHUB_ENV
           fi
 
+      - name: Test environment
+        run: |
+          echo "maintainer: '${GITHUB_ACTOR} <${GITHUB_ACTOR}@users.noreply.github.com>"
+          description: |
+            Pi Rack (U6143) OLED display service
+          vendor: "${GITHUB_REPOSITORY_OWNER}"
+          homepage: "${$GITHUB_SERVER_URL/$GITHUB_REPOSITORY}"'
+          
+
       - name: Create rpm package
         id: nfpm-rpm
         uses: burningalchemist/action-gh-nfpm@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Build binary
         run: |
           cd C && make clean && make && cd ..
+          cp C/display display-binary
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4

--- a/C/display.c
+++ b/C/display.c
@@ -3,6 +3,7 @@
  *********************************************************************/
 
 #include <signal.h>
+#include <stdio.h>
 #include <stdlib.h>      // exit
 #include <unistd.h>      // sleep, usleep
 #include "ssd1306_i2c.h" // LCD_Display, ssd1306_begin
@@ -27,11 +28,21 @@ void sig_handler(int signum) // Return type of the handler function should be vo
 
 int main(void)
 {
+  const char *cycle_time_env_name = "DISPLAY_CYCLE_TIME_S";
+  const int default_cycle_time = 1;
   unsigned short int count = 0;
 
   signal(SIGHUP, sig_handler);  // Register signal handler (can't catch SIGKILL or SIGSTOP)
   signal(SIGINT, sig_handler);  // Register signal handler (can't catch SIGKILL or SIGSTOP)
   signal(SIGTERM, sig_handler); // Register signal handler (can't catch SIGKILL or SIGSTOP)
+
+  const char *cycle_time_env_value = getenv(cycle_time_env_name);
+  int cycle_time;
+  if (cycle_time_env_value != NULL) {
+    cycle_time = atoi(cycle_time_env_value);
+  } else {
+    cycle_time = default_cycle_time;
+  }
 
   ssd1306_begin(SSD1306_SWITCHCAPVCC, SSD1306_I2C_ADDRESS); // LCD Screen initialization
   usleep(150000);                                           // Short delay to ensure the normal response of the lower functions
@@ -40,7 +51,7 @@ int main(void)
   for (;;)
   {
     LCD_Display(count);
-    sleep(1);
+    sleep(cycle_time);
     count++;
     if (count > 2)
     {

--- a/README.md
+++ b/README.md
@@ -23,11 +23,22 @@ wget https://github.com/josh-hemphill/U6143_ssd1306/releases/download/latest/dis
 sudo dpkg -i display-u6143.deb
 ```
 
+You can optionally set the DISPLAY_CYCLE_TIME_S environment variable to control the cycle time of the display
+Either in the global env locations or in the service file: /lib/systemd/system/display-u6143.service
+
+```ini
+[Service]
+Environment="DISPLAY_CYCLE_TIME_S=5"
+```
+
 Or if you just want to run the binary yourself:
 
 ```bash
-wget https://github.com/josh-hemphill/U6143_ssd1306/releases/download/latest/display`
-sudo dpkg -i display-u6143.deb
+wget https://github.com/josh-hemphill/U6143_ssd1306/releases/download/latest/display-binary`
+chmod +x display-binary
+# You can optionally set the DISPLAY_CYCLE_TIME_S environment variable
+# to control the cycle time of the display
+sudo DISPLAY_CYCLE_TIME_S=5 ./display-binary
 ```
 
 ## Clone U6143_ssd1306 library

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Display driver for UCTRONICS Ultimate Rack with PoE Functionality for Raspberry Pi 4 (SKU U6145)
 
 ## I2C
+
 Begin by enabling the I2C interface:
 
 ```bash
@@ -13,29 +14,52 @@ Choose `Interface Options` | `I2C`, then answer `Yes` to whether you would like 
 
 (On a freshly flashed Rasbian OS SD card, you can edit the `config.txt` file and uncomment `dtparam=i2c_arm=on` to enable I2C instead)
 
-## Clone U6143_ssd1306 library 
+## GitHub releases available now with pre-built binary and installer
+
+You can now install by downloading the latest `.deb` installer and it will automatically enable and start the background service.
+
+```bash
+wget https://github.com/josh-hemphill/U6143_ssd1306/releases/download/latest/display-u6143.deb`
+sudo dpkg -i display-u6143.deb
+```
+
+Or if you just want to run the binary yourself:
+
+```bash
+wget https://github.com/josh-hemphill/U6143_ssd1306/releases/download/latest/display`
+sudo dpkg -i display-u6143.deb
+```
+
+## Clone U6143_ssd1306 library
+
 ```bash
 git clone https://github.com/darkgrue/U6143_ssd1306.git
 ```
+
 Or if you don't have git installed (it's not by default)
+
 ```bash
 curl -sSL https://github.com/darkgrue/U6143_ssd1306/archive/refs/heads/master.zip -o temp.zip && unzip temp.zip && rm temp.zip
 ```
 
-## Compile 
+## Compile
+
 ```bash
 cd U6143_ssd1306/C
 ```
+
 ```bash
 make clean && make 
 ```
 
-## Run 
-```
+## Run
+
+```bash
 sudo ./display
 ```
 
 ## Add automatic start script
+
 Copy the binary file to `/usr/local/bin/`:
 
 ```bash
@@ -43,7 +67,7 @@ sudo cp ./display /usr/local/bin/
 ```
 
 Choose one of the following configuration options (`systemd` **or** `rc.local`):
- 
+
 ```bash
 sudo cp ./contrib/U6143_ssd1306.service /etc/systemd/system/
 sudo systemctl daemon-reload
@@ -69,7 +93,8 @@ Reboot your system:
 sudo reboot now
 ```
 
-## For older 0.91 inch LCD without MCU 
+## For older 0.91 inch LCD without MCU
+
 For the older version LCD without MCU controller, you can use the Python demo.
 
 Install the dependent library files:
@@ -82,7 +107,7 @@ sudo pip3 install adafruit-circuitpython-ssd1306
 
 Test demo:
 
-```bash 
+```bash
 cd U6143_ssd1306/python 
 sudo python3 ssd1306_stats.py
 ```

--- a/README.md
+++ b/README.md
@@ -11,16 +11,15 @@ sudo raspi-config
 
 Choose `Interface Options` | `I2C`, then answer `Yes` to whether you would like the ARM I2C interface to be enabled.
 
-Install Git and library dependencies
-
-```bash
-sudo apt update
-sudo apt install git wiringpi
-```
+(On a freshly flashed Rasbian OS SD card, you can edit the `config.txt` file and uncomment `dtparam=i2c_arm=on` to enable I2C instead)
 
 ## Clone U6143_ssd1306 library 
 ```bash
-git clone https://github.com/UCTRONICS/U6143_ssd1306.git
+git clone https://github.com/darkgrue/U6143_ssd1306.git
+```
+Or if you don't have git installed (it's not by default)
+```bash
+curl -sSL https://github.com/darkgrue/U6143_ssd1306/archive/refs/heads/master.zip -o temp.zip && unzip temp.zip && rm temp.zip
 ```
 
 ## Compile 

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://nfpm.goreleaser.com/static/schema.json
+
+name: "display-u6143"
+arch: "arm64"
+platform: "linux"
+version: "${PKG_VERSION}"
+section: "default"
+replaces:
+  - display-u6143
+provides:
+  - display-u6143
+maintainer: "${GITHUB_ACTOR} <${GITHUB_ACTOR}@users.noreply.github.com>"
+description: |
+  Pi Rack (U6143) OLED display service
+vendor: "${GITHUB_REPOSITORY_OWNER}"
+homepage: "${$GITHUB_SERVER_URL/$GITHUB_REPOSITORY}"
+license: "MIT"
+contents:
+  - src: ./display-binary
+    dst: /usr/local/bin/display-u6143
+  - src: ./packaging/service/systemd.service
+    dst: /lib/systemd/system/display-u6143.service
+    packager: deb|rpm
+  - src: ./packaging/service/openrc.service
+    dst: /etc/init.d/display-u6143
+    packager: apk
+overrides:
+  rpm:
+    scripts:
+      preinstall: ./packaging/pre-install.sh
+      postremove: ./packaging/post-remove.sh
+  deb:
+    scripts:
+      postinstall: ./packaging/post-install.sh
+      preremove: ./packaging/pre-remove.sh
+  apk:
+    scripts:
+      postinstall: ./packaging/apk/post-install.sh
+      preremove: ./packaging/apk/pre-remove.sh

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -27,7 +27,7 @@ contents:
 overrides:
   rpm:
     scripts:
-      preinstall: ./packaging/pre-install.sh
+      postinstall: ./packaging/post-install.sh
       postremove: ./packaging/post-remove.sh
   deb:
     scripts:

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -28,7 +28,7 @@ overrides:
   rpm:
     scripts:
       postinstall: ./packaging/post-install.sh
-      postremove: ./packaging/post-remove.sh
+      preremove: ./packaging/pre-remove.sh
   deb:
     scripts:
       postinstall: ./packaging/post-install.sh

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -18,6 +18,9 @@ license: "MIT"
 contents:
   - src: ./display-binary
     dst: /usr/local/bin/display-u6143
+    file_info:
+      mode: 0700
+
   - src: ./packaging/service/systemd.service
     dst: /etc/systemd/system/display-u6143.service
     packager: deb
@@ -27,6 +30,7 @@ contents:
   - src: ./packaging/service/openrc.service
     dst: /etc/init.d/display-u6143
     packager: apk
+
 overrides:
   rpm:
     scripts:

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -19,8 +19,11 @@ contents:
   - src: ./display-binary
     dst: /usr/local/bin/display-u6143
   - src: ./packaging/service/systemd.service
-    dst: /lib/systemd/system/display-u6143.service
-    packager: deb|rpm
+    dst: /etc/systemd/system/display-u6143.service
+    packager: deb
+  - src: ./packaging/service/systemd.service
+    dst: /etc/systemd/system/display-u6143.service
+    packager: rpm
   - src: ./packaging/service/openrc.service
     dst: /etc/init.d/display-u6143
     packager: apk

--- a/packaging/apk/post-install.sh
+++ b/packaging/apk/post-install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rc-update add display-u6143 default
+rc-service display-u6143 start

--- a/packaging/apk/pre-remove.sh
+++ b/packaging/apk/pre-remove.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rc-service display-u6143 stop
+rc-update del display-u6143 default

--- a/packaging/post-install.sh
+++ b/packaging/post-install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+systemctl enable display-u6143.service
+systemctl start display-u6143.service

--- a/packaging/pre-remove.sh
+++ b/packaging/pre-remove.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+systemctl stop display-u6143.service
+systemctl disable display-u6143.service

--- a/packaging/service/openrc.service
+++ b/packaging/service/openrc.service
@@ -1,0 +1,11 @@
+#!/sbin/openrc-run
+
+name="display-u6143"
+command="/usr/local/bin/display"
+command_background="yes"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+depend() {
+	need net
+	after bootmisc
+}

--- a/packaging/service/systemd.service
+++ b/packaging/service/systemd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Pi Rack (U6143) OLED display service
+After=network.target
+
+[Service]
+Type=idle
+ExecStart=/usr/local/bin/display
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/service/systemd.service
+++ b/packaging/service/systemd.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=idle
-ExecStart=/usr/local/bin/display
+ExecStart=/usr/local/bin/display-u6143
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I created github actions with the new ARM64 OSS runner to build a `.deb` package and create github releases with it.
So now I can just install by:
```bash
wget https://github.com/josh-hemphill/U6143_ssd1306/releases/download/latest/display-u6143.deb`
sudo dpkg -i display-u6143.deb
```
I fixed some outdated Readme stuff.
And I also added an environment variable setting to `display.c` so that the refresh interval can be configured on startup, or in the service file.

If you're going to merge this, just need to change the download url in the readme for the releases, didn't want the url on my repo to be a dead link in the interim.